### PR TITLE
Added the tests from cmake-d project

### DIFF
--- a/Tests/DC/CMakeLists.txt
+++ b/Tests/DC/CMakeLists.txt
@@ -9,3 +9,8 @@ add_executable(DC main.d)
 
 target_link_libraries(DC clib)
 
+# extra tests from cmake-d
+# build lib first
+add_subdirectory(lib_1)
+add_subdirectory(app_1)
+add_subdirectory(app_2)

--- a/Tests/DC/app_1/CMakeLists.txt
+++ b/Tests/DC/app_1/CMakeLists.txt
@@ -1,0 +1,11 @@
+# This is a D app that links a C library.
+#
+# The linker preference of D is higher than C (or CXX), so after
+# the objects are created, the D toolchain will drive linking.
+#
+include_directories(app_1 ${PROJECT_SOURCE_DIR})
+
+add_executable(app_1 app_1.d)
+target_link_libraries(app_1 lib_1)
+
+add_test(app_1 app_1)

--- a/Tests/DC/app_1/app_1.d
+++ b/Tests/DC/app_1/app_1.d
@@ -1,0 +1,14 @@
+import lib_1.lib_1_import;
+
+// extern(C) int c_func_add_1(int x);
+
+int main()
+{
+	int x = 1;
+	int y;
+
+	y = c_func_add_1(x);
+
+	assert(y == x + 1);
+	return 0;
+}

--- a/Tests/DC/app_2/CMakeLists.txt
+++ b/Tests/DC/app_2/CMakeLists.txt
@@ -1,0 +1,16 @@
+# This is a D app that links a C object.
+#
+# The linker preference of D is higher than C (or CXX), so after
+# the objects are created, the D toolchain will drive linking.
+#
+# TODO
+# dirty fix
+# we should make the CMAKE_D_COMPILER_ID work
+# 
+# This 32-bit environment check no longer needed as of dmd 2.053 on Linux
+#IF("${CMAKE_BASE_NAME}" MATCHES "dmd")
+#	SET(CMAKE_C_FLAGS "-m32 ${CMAKE_C_FLAGS}" )
+#ENDIF()
+add_executable(app_2 app_2.d cfunc.c)
+
+add_test(app_2 app_2)

--- a/Tests/DC/app_2/app_2.d
+++ b/Tests/DC/app_2/app_2.d
@@ -1,0 +1,12 @@
+extern(C) int cfunc(int x);
+
+int main()
+{
+	int x = 1;
+	int y;
+
+	y = cfunc(x);
+	
+    assert(y == x + 1);
+	return 0;
+}

--- a/Tests/DC/app_2/cfunc.c
+++ b/Tests/DC/app_2/cfunc.c
@@ -1,0 +1,4 @@
+int cfunc(int x)
+{
+	return x + 1;
+}

--- a/Tests/DC/lib_1/CMakeLists.txt
+++ b/Tests/DC/lib_1/CMakeLists.txt
@@ -1,0 +1,4 @@
+# This project is a C library
+project(lib_1 C)
+
+add_library(lib_1 STATIC lib_1.c)

--- a/Tests/DC/lib_1/lib_1.c
+++ b/Tests/DC/lib_1/lib_1.c
@@ -1,0 +1,4 @@
+int c_func_add_1(int x)
+{
+	return x + 1;
+}

--- a/Tests/DC/lib_1/lib_1_import.d
+++ b/Tests/DC/lib_1/lib_1_import.d
@@ -1,0 +1,1 @@
+extern(C) int c_func_add_1(int x);

--- a/Tests/DOnly/CMakeLists.txt
+++ b/Tests/DOnly/CMakeLists.txt
@@ -14,3 +14,12 @@ target_link_libraries(DOnly hello world)
 
 # TODO: Adds unsupported compiler flags
 # add_library(testDModule MODULE testDModule.d)
+
+# extra tests from cmake-d
+# build lib first
+add_subdirectory(lib_1)
+add_subdirectory(app_1)
+add_subdirectory(app_2)
+add_subdirectory(app_3)
+add_subdirectory(app_4)
+add_subdirectory(app_5)

--- a/Tests/DOnly/app_1/CMakeLists.txt
+++ b/Tests/DOnly/app_1/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(app_1 app_1.d)
+
+add_test(app_1 app_1)

--- a/Tests/DOnly/app_1/app_1.d
+++ b/Tests/DOnly/app_1/app_1.d
@@ -1,0 +1,7 @@
+/*
+ Barebones app, depends on nothing.
+*/
+int main()
+{
+    return 0;
+}

--- a/Tests/DOnly/app_2/CMakeLists.txt
+++ b/Tests/DOnly/app_2/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(app_2 app_2.d)
+
+add_test(app_2 app_2)

--- a/Tests/DOnly/app_2/app_2.d
+++ b/Tests/DOnly/app_2/app_2.d
@@ -1,0 +1,8 @@
+// barebones app, depends on the standard library
+import std.stdio;
+
+int main()
+{
+	writeln("Hello World!"); 
+	return 0;
+}

--- a/Tests/DOnly/app_3/CMakeLists.txt
+++ b/Tests/DOnly/app_3/CMakeLists.txt
@@ -1,0 +1,6 @@
+include_directories(app_3 ${PROJECT_SOURCE_DIR})
+
+add_executable(app_3 app_3.d)
+target_link_libraries(app_3 lib_1)
+
+add_test(app_3 app_3)

--- a/Tests/DOnly/app_3/app_3.d
+++ b/Tests/DOnly/app_3/app_3.d
@@ -1,0 +1,9 @@
+import lib_1.lib_1;
+
+int main()
+{
+	int x = 1;
+	int y = lib_1_func(x);
+	assert(y == x + 1);
+	return 0;
+}

--- a/Tests/DOnly/app_4/CMakeLists.txt
+++ b/Tests/DOnly/app_4/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(app_4 app_4.d)
+
+add_test(app_4 app_4)

--- a/Tests/DOnly/app_4/app_4.d
+++ b/Tests/DOnly/app_4/app_4.d
@@ -1,0 +1,79 @@
+import std.stdio;
+import core.thread;
+import std.datetime;
+
+// Yield count should be larger for a more accurate measurment, but this
+// is just a unit tests, so don't spin for long
+immutable uint yield_count = 1000;
+immutable uint worker_count = 10;
+
+void fiber_func()
+{
+	uint i = yield_count;
+	while (--i)
+		Fiber.yield();
+}
+
+void thread_func()
+{
+	uint i = yield_count;
+	while (--i)
+		Thread.yield();
+}
+
+void fiber_test()
+{
+	Fiber[worker_count] fib_array;
+
+	foreach (ref f; fib_array)
+		f = new Fiber(&fiber_func);
+
+	StopWatch sw;
+
+	uint i = yield_count;
+
+	// fibers are cooperative and need a driver loop
+	sw.start();
+	bool done;
+
+	do
+	{	
+		done = true;
+		foreach (f; fib_array)
+		{
+			f.call();
+			if (f.state() != f.State.TERM)
+				done = false;
+		}
+	} while (!done);
+	sw.stop();
+
+	writeln("Elapsed time for ", worker_count, " workers times ", yield_count,
+		" yield() calls with fibers = ", sw.peek().msecs, "ms");
+}
+
+void thread_test()
+{
+	Thread[worker_count] thread_array;
+
+	foreach (ref t; thread_array)
+		t = new Thread(&thread_func);
+
+	StopWatch sw;
+	sw.start();
+
+	foreach (t; thread_array)
+		t.start();
+
+	thread_joinAll();
+	sw.stop();
+	writeln("Elapsed time for ", worker_count, " workers times ", yield_count,
+		" yield() calls with threads = ", sw.peek().msecs, "ms");
+}
+
+int main()
+{
+	fiber_test();
+	thread_test();
+	return 0;
+}

--- a/Tests/DOnly/app_5/CMakeLists.txt
+++ b/Tests/DOnly/app_5/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(app_5 app_5.d a.d)

--- a/Tests/DOnly/app_5/a.d
+++ b/Tests/DOnly/app_5/a.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void print_hello_world()
+{
+    writeln("Hello World!");
+}

--- a/Tests/DOnly/app_5/app_5.d
+++ b/Tests/DOnly/app_5/app_5.d
@@ -1,0 +1,8 @@
+import std.stdio;
+import a;
+
+int main()
+{
+	print_hello_world();
+	return 0;
+}

--- a/Tests/DOnly/lib_1/CMakeLists.txt
+++ b/Tests/DOnly/lib_1/CMakeLists.txt
@@ -1,0 +1,1 @@
+ADD_LIBRARY (lib_1 lib_1.d)

--- a/Tests/DOnly/lib_1/lib_1.d
+++ b/Tests/DOnly/lib_1/lib_1.d
@@ -1,0 +1,6 @@
+module lib_1.lib_1_func;
+
+int lib_1_func(uint x)
+{
+	return x + 1;
+}

--- a/Tests/UseD/CMakeLists.txt
+++ b/Tests/UseD/CMakeLists.txt
@@ -14,3 +14,6 @@ include_directories(${HEADER_CHECKER_INCLUDE_DIR})
 
 add_executable(UseD main.d)
 target_link_libraries(UseD conditions ddocChecker enforceProperty headerChecker)
+
+# # extra tests from cmake-d
+# add_subdirectory(app_1)

--- a/Tests/UseD/app_1/CMakeLists.txt
+++ b/Tests/UseD/app_1/CMakeLists.txt
@@ -1,0 +1,13 @@
+file(GLOB files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.d")
+
+include(UseD)
+
+enable_testing()
+
+foreach(file IN LISTS files)
+    get_filename_component(executable ${file} NAME_WE)
+    add_library(${executable} ${file})
+    add_d_unittests("test_${executable}"
+        TARGET ${executable}
+        SOURCES ${file})
+endforeach()

--- a/Tests/UseD/app_1/moduleA.d
+++ b/Tests/UseD/app_1/moduleA.d
@@ -1,0 +1,4 @@
+unittest
+{
+	assert(true);
+}

--- a/Tests/UseD/app_1/moduleB.d
+++ b/Tests/UseD/app_1/moduleB.d
@@ -1,0 +1,4 @@
+unittest
+{
+	assert(true);
+}


### PR DESCRIPTION
There are still two omissions:
- test `Tests/DOnly/app_5` actually should detected automatically the `a.d` dependency, but I could not found such a functionality in the current implementation.
- test `Tests/UseD/app_1` is commented out. I cannot figure it out how to use `add_d_unittests`.
