### PR TITLE
ddeps: fix -fdebug parsing for GNU

### DIFF
--- a/Source/DDeps/ddeps.cxx
+++ b/Source/DDeps/ddeps.cxx
@@ -170,7 +170,7 @@ int main(int argc, char const* const* argv)
       arg.AddArgument("-I", argT::CONCAT_ARGUMENT, &includeDirs, "");
       arg.AddArgument("-J", argT::CONCAT_ARGUMENT, &textIncludeDirs, "");
       arg.AddArgument("-fversion", argT::EQUAL_ARGUMENT, &versionIdents, "");
-      arg.AddArgument("-fdebug", argT::EQUAL_ARGUMENT, &debugIdents, "");
+      arg.AddArgument("-fdebug=", argT::CONCAT_ARGUMENT, &debugIdents, "");
       arg.AddArgument("-funittest", argT::NO_ARGUMENT, &unittest, "");
       arg.AddArgument("-o", argT::CONCAT_ARGUMENT, &obj, "");
       flagsSet = true;


### PR DESCRIPTION
The -fdebug flag may be used standalone and the parser is unhappy when
an EQUAL_ARGUMENT doesn't have a trailing '='. Instead, match -fdebug=
as a CONCAT_ARGUMENT.

---

Fixes #19 for me.
